### PR TITLE
Replace np.float with builtin type float

### DIFF
--- a/xplt/timestructure.py
+++ b/xplt/timestructure.py
@@ -721,7 +721,7 @@ class TimeIntervalPlot(XManifoldPlot, ParticlePlotMixin, ParticleHistogramPlotMi
                         range=(0, self.bin_count * self.bin_time),
                         weights=weights,
                     )
-                    counts = counts.astype(np.float)
+                    counts = counts.astype(float)
                     if p in ("rate", "current"):
                         counts /= self.bin_time
                     if self.relative:


### PR DESCRIPTION
np.float and np.int were deprecated with release 1.20.0

   https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

and eventually dropped with release 1.24.0

   https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations

(Alternatively, np.float can be replaced by np.float64)

<!-- Add a description of the goal of this merge request -->

This PR ...

<!-- List all introduced changes, features, etc. -->

- ...

<!-- Link related issues or issues beeing fixed -->

Closes #...


### Testing

<!-- Describe the steps taken to test the changes you've proposed -->

...

<!-- Add screenshots/outputs/etc. of the behaviour before/after your changes -->

| Before | After |
|--------|-------|
|  ...   |  ...  |



-----
My contribution follows "inbound=outbound" licensing as defined by the [GitHub Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license).